### PR TITLE
Fix docker tag example

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -130,7 +130,7 @@ The platform comes installed with an admin user (its password is set on the RTF 
     - Tag your image so you can push the image to this repository:
 
       ```
-      docker tag remediatetheflag/rtf-exercises:latest 1234567891234.dkr.ecr.us-east-2.amazonaws.com/remediatetheflag/exercises:vulnerableappjava-1.0
+      docker tag remediatetheflag/exercise-vulnerableappjava:1.0 1234567891234.dkr.ecr.us-east-2.amazonaws.com/remediatetheflag/exercises:vulnerableappjava-1.0
       ```
 
     - Run the following command to push this image to your newly created AWS repository:


### PR DESCRIPTION
When I followed the example commands, I encountered the following error:
```
Error response from daemon: No such image: remediatetheflag/rtf-exercises:latest
```
The example has you pull down `remediatetheflag/exercise-vulnerableappjava:1.0` so I presume that's the example image you ought to be tagging. If I misunderstood the instructions, I would love to talk about it so we can clarify what you're supposed to do in the example.