### PR TITLE
Fix for StatsUtil.java class in RTF-Portal project

### DIFF
--- a/RTF-Portal/src/main/java/com/remediatetheflag/global/controllers/ActionsController.java
+++ b/RTF-Portal/src/main/java/com/remediatetheflag/global/controllers/ActionsController.java
@@ -20,6 +20,8 @@
 package com.remediatetheflag.global.controllers;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -159,7 +161,9 @@ public abstract class ActionsController {
 			request.setAttribute(Constants.REQUEST_ATTRIBUTE_JSON, jsonObject);
 			action.doAction(request,response);	
 		} catch ( Exception  e) {
-			logger.error("Action Exception: "+actionClass.toString()+" for user: "+usr+"\n" + e.getMessage() );
+			StringWriter errors = new StringWriter();
+			e.printStackTrace(new PrintWriter(errors));
+			logger.error("Action Exception: "+actionClass.toString()+" for user: "+usr+"\n" + e.getMessage()+"\n"+errors.toString() );
 			MessageGenerator.sendErrorMessage(Constants.JSON_VALUE_ERROR_ACTION_EXCEPTION, response);
 		}
 

--- a/RTF-Portal/src/main/java/com/remediatetheflag/global/utils/StatsUtils.java
+++ b/RTF-Portal/src/main/java/com/remediatetheflag/global/utils/StatsUtils.java
@@ -36,6 +36,15 @@ public class StatsUtils {
 		long diffInMillies = date2.getTime() - date1.getTime();
 		return TimeUnit.MILLISECONDS.toMinutes(diffInMillies); 
 	}
+	
+	private HashMap<String,Integer> initializeMapWithExerciseResultStatus(){
+		HashMap<String,Integer> tmpMap = new HashMap<String,Integer>();
+		for(ExerciseResultStatus ers: ExerciseResultStatus.values()) {
+			tmpMap.put(ers.toString(),0);
+		}
+		return tmpMap;
+	}
+	
 	public void setTimePerCategory(List<ExerciseInstance> exerciseInstances, Stats stats){
 		
 		Map<String, Long> totalTimeEach = new HashMap<String, Long>();
@@ -123,11 +132,7 @@ public class StatsUtils {
 
 		for(ExerciseInstance ei : exerciseInstances){
 			if(!irr.containsKey(ei.getRegion().toString())){
-				Map<String,Integer> tmpMap = new HashMap<String,Integer>();
-				tmpMap.put(ExerciseResultStatus.NOT_VULNERABLE.toString(),0);
-				tmpMap.put(ExerciseResultStatus.VULNERABLE.toString(),0);
-				tmpMap.put(ExerciseResultStatus.BROKEN_FUNCTIONALITY.toString(),0);
-				tmpMap.put(ExerciseResultStatus.NOT_ADDRESSED.toString(),0);
+				Map<String,Integer> tmpMap = initializeMapWithExerciseResultStatus();
 				irr.put(ei.getRegion().toString(), tmpMap);
 			}
 			Map<String,Integer> tmpStatus = irr.get(ei.getRegion().toString());
@@ -145,11 +150,7 @@ public class StatsUtils {
 			if(null==ei.getUser().getTeam())
 				continue;
 			if(!irr.containsKey(ei.getUser().getTeam().getName())){
-				Map<String,Integer> tmpMap = new HashMap<String,Integer>();
-				tmpMap.put(ExerciseResultStatus.NOT_VULNERABLE.toString(),0);
-				tmpMap.put(ExerciseResultStatus.VULNERABLE.toString(),0);
-				tmpMap.put(ExerciseResultStatus.BROKEN_FUNCTIONALITY.toString(),0);
-				tmpMap.put(ExerciseResultStatus.NOT_ADDRESSED.toString(),0);
+				Map<String,Integer> tmpMap = initializeMapWithExerciseResultStatus();
 				irr.put(ei.getUser().getTeam().getName(), tmpMap);
 			}
 			Map<String,Integer> tmpStatus = irr.get(ei.getUser().getTeam().getName());
@@ -166,11 +167,7 @@ public class StatsUtils {
 		for(ExerciseInstance ei : exerciseInstances){
 			for(ExerciseResult er : ei.getResults()){
 				if(!irr.containsKey(er.getCategory())){
-					Map<String,Integer> tmpMap = new HashMap<String,Integer>();
-					tmpMap.put(ExerciseResultStatus.NOT_VULNERABLE.toString(),0);
-					tmpMap.put(ExerciseResultStatus.VULNERABLE.toString(),0);
-					tmpMap.put(ExerciseResultStatus.BROKEN_FUNCTIONALITY.toString(),0);
-					tmpMap.put(ExerciseResultStatus.NOT_ADDRESSED.toString(),0);
+					Map<String,Integer> tmpMap = initializeMapWithExerciseResultStatus();
 					irr.put(er.getCategory(), tmpMap);
 				}
 				Map<String,Integer> tmpStatus = irr.get(er.getCategory());
@@ -186,11 +183,7 @@ public class StatsUtils {
 		for(ExerciseInstance ei : exerciseInstances){
 			for(ExerciseResult er : ei.getResults()){
 				if(!irr.containsKey(er.getName())){
-					Map<String,Integer> tmpMap = new HashMap<String,Integer>();
-					tmpMap.put(ExerciseResultStatus.NOT_VULNERABLE.toString(),0);
-					tmpMap.put(ExerciseResultStatus.VULNERABLE.toString(),0);
-					tmpMap.put(ExerciseResultStatus.BROKEN_FUNCTIONALITY.toString(),0);
-					tmpMap.put(ExerciseResultStatus.NOT_ADDRESSED.toString(),0);
+					Map<String,Integer> tmpMap = initializeMapWithExerciseResultStatus();
 					irr.put(er.getName(), tmpMap);
 				}
 				Map<String,Integer> tmpStatus = irr.get(er.getName());


### PR DESCRIPTION
We were having problems to display the statistics for one of our organizations in the platform, and in the log the error message was null as we described in [this isssue](https://github.com/sk4ddy/remediatetheflag/issues/14).
We followed your recomendation to add a few lines of code to see the problem and found this error:

`2019-09-26 18:36:45 ERROR ActionsController:168 - Action Exception: class com.remediatetheflag.global.actions.auth.ma                       nagement.monitor.GetStatsGlobalAction for user: 44
null
java.lang.NullPointerException
        at com.remediatetheflag.global.utils.StatsUtils.getRemediationRatePerIssue(StatsUtils.java:197)
        at com.remediatetheflag.global.actions.auth.management.monitor.GetStatsGlobalAction.doAction(GetStatsGlobalAc                       tion.java:154)
        at com.remediatetheflag.global.controllers.ActionsController.executeAction(ActionsController.java:163)
        at com.remediatetheflag.global.servlets.MonitorServlet.doPost(MonitorServlet.java:43)`

Debugging the code we discovered that one ExerciseResultStatus that the platform was trying to process had the status NOT_AVAILABLE, that is not being covered in this lines of code in StatsUtil.java class:

`
Map<String,Integer> tmpMap = new HashMap<String,Integer>();
					tmpMap.put(ExerciseResultStatus.NOT_VULNERABLE.toString(),0);
					tmpMap.put(ExerciseResultStatus.VULNERABLE.toString(),0);
					tmpMap.put(ExerciseResultStatus.BROKEN_FUNCTIONALITY.toString(),0);
					tmpMap.put(ExerciseResultStatus.NOT_ADDRESSED.toString(),0);
`

So when the platform tried to run this piece of code `tmpStatus.put(er.getStatus().toString(), (tmpStatus.get(er.getStatus().toString())+1));` the `tmpStatus.get(er.getStatus().toString()` was returning null because the entry ExerciseResultStatus.NOT_AVAILABLE is not on the HashMap.
To solve it, we created a function to populate the tmpMap variable with all the entries available in the ExerciseResultStatus enum as you can see in the pull request, and all the organizations statistics come back to work properly.

We were glad to help improve the platform, thanks for the support.